### PR TITLE
correct spacing in dashboard deploy workflow

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main  # Set a branch name to trigger deploy
     paths:
-    - 'dashboard'
+      - 'dashboard' 
 
 jobs:
   deploy:


### PR DESCRIPTION
The dashboard deploy workflow was not being triggered and it seems the spacing was incorrect for the path causing the failure.