### PR TITLE
update dependencies and support Intellij IDEA builds up to version 2022.3.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 # TSDetect Changelog
 
+## [0.0.2]
+Upgrade dependencies to latest versions:
+- `org.jetbrains.intellij` to version `1.13.1`
+- `org.jetbrains.changelog` to version `2.0.0`
+
+Support newer versions of Intellij IDEA:
+- Updated gradle property of `pluginUntilBuild` to `223.*` to support latest 2022.3.* versions of IDE
+
 ## [Unreleased]
 ### Added
 - Initial scaffold created from [IntelliJ Platform Plugin Template](https://github.com/JetBrains/intellij-platform-plugin-template)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,9 +9,9 @@ plugins {
     // Kotlin support
     id("org.jetbrains.kotlin.jvm") version "1.6.0"
     // Gradle IntelliJ Plugin
-    id("org.jetbrains.intellij") version "1.3.0"
+    id("org.jetbrains.intellij") version "1.13.1"
     // Gradle Changelog Plugin
-    id("org.jetbrains.changelog") version "1.3.1"
+    id("org.jetbrains.changelog") version "2.0.0"
     // Gradle Qodana Plugin
     id("org.jetbrains.qodana") version "0.1.13"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,16 +4,16 @@
 pluginGroup = org.scanl
 pluginName = TSDetect
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.1
+pluginVersion = 0.0.2
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 203
-pluginUntilBuild = 213.*
+pluginUntilBuild = 223.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 2021.2.1
+platformVersion = 2021.3.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22


### PR DESCRIPTION
Upgrade dependencies to latest versions:
- `org.jetbrains.intellij` to version `1.13.1`
- `org.jetbrains.changelog` to version `2.0.0`

Support newer versions of Intellij IDEA:
- Updated gradle property of `pluginUntilBuild` to `223.*` to support latest 2022.3.* versions of IDE